### PR TITLE
Add compatibility with motion smoothing's fractional camera positions

### DIFF
--- a/Code/Entities/Mask.cs
+++ b/Code/Entities/Mask.cs
@@ -92,8 +92,12 @@ public class Mask : Entity {
     public Rectangle GetVisibleRect()
         => Rectangle.Intersect(new Rectangle(0, 0, Level.Camera.Viewport.Width, Level.Camera.Viewport.Height), new Rectangle((int)(X - Level.Camera.X), (int)(Y - Level.Camera.Y), (int)Width, (int)Height));
 
-    public Vector2 GetDrawPos()
-        => new Vector2(Math.Max(X, Level.Camera.X), Math.Max(Y, Level.Camera.Y));
+    public Vector2 GetDrawPos() {
+        // Get the draw position frrom the source rectangle
+        // in order to support fractional camera positions
+        Rectangle sourceRect = GetVisibleRect();
+        return new Vector2(sourceRect.X + Level.Camera.X, sourceRect.Y + Level.Camera.Y);
+    }
 
     public Vector2 GetDrawOffset()
         => new Vector2(Math.Max(0, Level.Camera.X - X), Math.Max(0, Level.Camera.Y - Y));


### PR DESCRIPTION
This PR fixes jitter in styleground masks when the camera position is fractional. It replaces the Max call in `GetDrawPos` with the implicit intersection from `GetVisibleRect`, then adds the camera position to that casted value. I've tested this (via SJ's implementation of this code), and it works perfectly to the best of my knowledge.